### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/cloud-iq-deno/routes/api/sync/manual.ts
+++ b/cloud-iq-deno/routes/api/sync/manual.ts
@@ -52,10 +52,10 @@ export const handler: Handlers = {
       return new Response(
         JSON.stringify({
           success: false,
-          message: `Manual sync failed: ${error instanceof Error ? error.message : String(error)}`,
+          message: "Manual sync failed due to an internal error.",
           syncedCount: 0,
           errorCount: 1,
-          errors: [error instanceof Error ? error.message : String(error)],
+          errors: ["An internal error occurred. Please contact support if the issue persists."],
           timestamp: new Date().toISOString(),
         }),
         {


### PR DESCRIPTION
Potential fix for [https://github.com/mikkihugo/hostbill/security/code-scanning/1](https://github.com/mikkihugo/hostbill/security/code-scanning/1)

To fix the issue, we will ensure that no sensitive information, such as stack traces or internal error messages, is exposed to the client. Instead, we will log the detailed error information on the server and return a generic error message to the client. Specifically:
1. Replace the `error.message` and `String(error)` in the response body with a generic error message.
2. Log the full error details (including the stack trace) on the server for debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
